### PR TITLE
Remove duplicate null checks

### DIFF
--- a/src/main/java/org/omnimc/asm/manager/multi/MultiClassManager.java
+++ b/src/main/java/org/omnimc/asm/manager/multi/MultiClassManager.java
@@ -128,8 +128,6 @@ public class MultiClassManager {
      * @throws RuntimeException If any of the input files are not JAR files or an I/O error occurs during file reading.
      */
     public void readJarFiles(@NotNull File... fileInputs) {
-        Objects.requireNonNull(fileInputs); //TODO why double null check...?
-
         for (File fileInput : fileInputs) {
             if (!fileInput.getName().endsWith(".jar")) {
                 ExceptionHandler.handleException(new IllegalArgumentException("Input File have to be a JAR file!"));

--- a/src/main/java/org/omnimc/asm/merger/JarMerger.java
+++ b/src/main/java/org/omnimc/asm/merger/JarMerger.java
@@ -86,8 +86,6 @@ public class JarMerger {
      * @throws IllegalArgumentException If {@code mergedJarName} does not end with ".jar".
      */
     public JarMerger(@NotNull String mergedJarName) {
-        Objects.requireNonNull(mergedJarName); //TODO double null check...?
-
         if (!mergedJarName.endsWith(".jar")) {
             ExceptionHandler.handleException(mergedJarName + ", does not end in '.jar'. This needs to be a JAR file!", new IllegalArgumentException());
         }


### PR DESCRIPTION
`Objects.requireNonNull` is unnecessary for parameters annotated `@NotNull`.